### PR TITLE
feat(sales): add income calculation for sales

### DIFF
--- a/src/test/java/ma/yc/Citronix/sale/SaleServiceUnitTest.java
+++ b/src/test/java/ma/yc/Citronix/sale/SaleServiceUnitTest.java
@@ -1,6 +1,7 @@
 package ma.yc.Citronix.sale;
 
 import ma.yc.Citronix.common.domain.exception.NotFoundException;
+import ma.yc.Citronix.harvest.application.dto.response.HarvestResponseDto;
 import ma.yc.Citronix.harvest.domain.model.aggregate.Harvest;
 import ma.yc.Citronix.harvest.domain.service.HarvestService;
 import ma.yc.Citronix.sale.application.dto.request.SaleRequestDto;
@@ -74,14 +75,23 @@ class SaleServiceTest {
     }
 
     private SaleResponseDto createExpectedResponse(Sale sale) {
+        HarvestResponseDto harvestResponseDto = new HarvestResponseDto(
+                sale.getHarvest().getId(),
+                sale.getHarvest().getSeason(),
+                sale.getHarvest().getDate(),
+                sale.getHarvest().getTotalQuantity()
+        );
+
         return new SaleResponseDto(
                 sale.getId(),
                 sale.getDate(),
                 sale.getClient(),
                 sale.getUnitPrice(),
-                null // HarvestResponseDto would be set here in real scenario
+                null,  // Replace this with the actual value if needed
+                harvestResponseDto  // Pass the actual HarvestResponseDto here
         );
     }
+
 
     @Nested
     class FindAllTests {
@@ -177,7 +187,7 @@ class SaleServiceTest {
             given(saleRepository.findById(testSaleId)).willReturn(Optional.of(testSale));
             given(saleRepository.save(any(Sale.class))).willReturn(testSale);
             given(saleMapper.toResponseDto(any(Sale.class)))
-                    .willReturn(new SaleResponseDto(testSaleId, SALE_DATE, updatedClient, UNIT_PRICE, null));
+                    .willReturn(new SaleResponseDto(testSaleId, SALE_DATE, updatedClient, UNIT_PRICE, 10.6 , null));
 
             SaleResponseDto result = saleService.update(testSaleId, request);
 


### PR DESCRIPTION
- Implement logic to calculate total income from sales
- Update SalesService to include income computation
- Ensure accurate calculations based on unit price and quantity
- Add tests to validate income calculation functionality JIRA: CIT-28